### PR TITLE
docs: correct link to responsive variants

### DIFF
--- a/pages/docs/slots.mdx
+++ b/pages/docs/slots.mdx
@@ -317,7 +317,7 @@ export default App;
 
 ### Slots with responsive variants
 
-**Tailwind Variants** also allows you to apply responsive variants to your slots. See more about responsive variants [here](/docs/responsive-variants).
+**Tailwind Variants** also allows you to apply responsive variants to your slots. See more about responsive variants [here](/docs/variants#responsive-variants).
 
 <br/>
 


### PR DESCRIPTION
* updates link to responsive variants section on the slots page