### PR TITLE
fix: support CSS variables in class regex

### DIFF
--- a/pages/docs/getting-started.mdx
+++ b/pages/docs/getting-started.mdx
@@ -189,7 +189,7 @@ If you are using **VSCode** and the [**TailwindCSS IntelliSense Extension**](htt
 ```json copy
 {
   "tailwindCSS.experimental.classRegex": [
-    ["tv\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]
+    ["tv\\((([^()]*|\\([^()]*\\))*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]
   ]
 }
 ```


### PR DESCRIPTION
Updates the classRegex to better support class names including css variables (e.g. `text-[var(--foo)]`).

Fixes #17 