### PR TITLE
feat: added example and explanation for using slots in compound variants

### DIFF
--- a/components/examples/index.ts
+++ b/components/examples/index.ts
@@ -4,3 +4,4 @@ export { default as SlotsVariantsExample } from './slots-variants-example';
 export { default as SlotsResponsiveVariantsExample } from './slots-responsive-variants-example';
 export { default as ResponsiveVariantsExample } from './responsive-variants-example';
 export { default as CompoundSlotsExample } from './compound-slots-example';
+export { default as SlotsCompoundVariantsExample } from './slots-compound-variants-example';

--- a/components/examples/slots-compound-variants-example.tsx
+++ b/components/examples/slots-compound-variants-example.tsx
@@ -48,18 +48,18 @@ const alert = tv({
       variant: 'filled',
       severity: 'error',
       class: {
-        root: 'bg-red-500',
-        title: 'text-red-900',
-        message: 'text-red-800'
+        root: 'bg-red-100 dark:bg-red-800',
+        title: 'text-red-900 dark:text-red-50',
+        message: 'text-red-700 dark:text-red-200'
       }
     },
     {
       variant: 'filled',
       severity: 'success',
       class: {
-        root: 'bg-green-500',
-        title: 'text-green-900',
-        message: 'text-green-800'
+        root: 'bg-green-100 dark:bg-green-800',
+        title: 'text-green-900 dark:text-green-50',
+        message: 'text-green-700 dark:text-green-200'
       }
     }
   ],

--- a/components/examples/slots-compound-variants-example.tsx
+++ b/components/examples/slots-compound-variants-example.tsx
@@ -7,7 +7,7 @@ import { RadioGroup, Radio } from '@components';
 
 const alert = tv({
   slots: {
-    root: 'rounded py-3 px-5',
+    root: 'rounded py-3 px-5 mb-4',
     title: 'font-bold mb-1',
     message: ''
   },
@@ -78,7 +78,7 @@ const SlotsCompoundVariantsExample = () => {
   const { root, message, title } = alert({ severity, variant });
 
   return (
-    <div className="my-6">
+    <>
       <div className={root()}>
         <div className={title()}>Oops, something went wrong</div>
         <div className={message()}>
@@ -97,7 +97,7 @@ const SlotsCompoundVariantsExample = () => {
         <Radio value="filled">Filled</Radio>
         <Radio value="outlined">Outlined</Radio>
       </RadioGroup>
-    </div>
+    </>
   );
 };
 

--- a/components/examples/slots-compound-variants-example.tsx
+++ b/components/examples/slots-compound-variants-example.tsx
@@ -30,18 +30,18 @@ const alert = tv({
       variant: 'outlined',
       severity: 'error',
       class: {
-        root: 'border-red-500',
+        root: 'border-red-700 dark:border-red-500',
         title: 'text-red-700 dark:text-red-500',
-        message: 'text-red-600'
+        message: 'text-red-600 dark:text-red-500'
       }
     },
     {
       variant: 'outlined',
       severity: 'success',
       class: {
-        root: 'border-green-500',
+        root: 'border-green-700 dark:border-green-500',
         title: 'text-green-700 dark:text-green-500',
-        message: 'text-green-500'
+        message: 'text-green-600 dark:text-green-500'
       }
     },
     {
@@ -49,8 +49,8 @@ const alert = tv({
       severity: 'error',
       class: {
         root: 'bg-red-500',
-        title: 'text-red-100',
-        message: 'text-red-200'
+        title: 'text-red-900',
+        message: 'text-red-800'
       }
     },
     {
@@ -58,8 +58,8 @@ const alert = tv({
       severity: 'success',
       class: {
         root: 'bg-green-500',
-        title: 'text-green-100',
-        message: 'text-green-200'
+        title: 'text-green-900',
+        message: 'text-green-800'
       }
     }
   ],

--- a/components/examples/slots-compound-variants-example.tsx
+++ b/components/examples/slots-compound-variants-example.tsx
@@ -1,0 +1,104 @@
+import type { VariantProps } from 'tailwind-variants';
+
+import { tv } from 'tailwind-variants';
+import { useState } from 'react';
+
+import { RadioGroup, Radio } from '@components';
+
+const alert = tv({
+  slots: {
+    root: 'rounded py-3 px-5',
+    title: 'font-bold mb-1',
+    message: ''
+  },
+  variants: {
+    variant: {
+      outlined: {
+        root: 'border'
+      },
+      filled: {
+        root: ''
+      }
+    },
+    severity: {
+      error: '',
+      success: ''
+    }
+  },
+  compoundVariants: [
+    {
+      variant: 'outlined',
+      severity: 'error',
+      class: {
+        root: 'border-red-500',
+        title: 'text-red-700 dark:text-red-500',
+        message: 'text-red-600'
+      }
+    },
+    {
+      variant: 'outlined',
+      severity: 'success',
+      class: {
+        root: 'border-green-500',
+        title: 'text-green-700 dark:text-green-500',
+        message: 'text-green-500'
+      }
+    },
+    {
+      variant: 'filled',
+      severity: 'error',
+      class: {
+        root: 'bg-red-500',
+        title: 'text-red-100',
+        message: 'text-red-200'
+      }
+    },
+    {
+      variant: 'filled',
+      severity: 'success',
+      class: {
+        root: 'bg-green-500',
+        title: 'text-green-100',
+        message: 'text-green-200'
+      }
+    }
+  ],
+  defaultVariants: {
+    variant: 'filled',
+    severity: 'success'
+  }
+});
+
+type Variants = VariantProps<typeof alert>;
+
+const SlotsCompoundVariantsExample = () => {
+  const [severity, setSeverity] = useState<Variants['severity']>('success');
+  const [variant, setVariant] = useState<Variants['variant']>('filled');
+
+  const { root, message, title } = alert({ severity, variant });
+
+  return (
+    <div className="my-6">
+      <div className={root()}>
+        <div className={title()}>Oops, something went wrong</div>
+        <div className={message()}>
+          Something went wrong saving your changes. Try again later.
+        </div>
+      </div>
+      <RadioGroup
+        label="Select severity:"
+        value={severity}
+        onChange={setSeverity}
+      >
+        <Radio value="success">Success</Radio>
+        <Radio value="error">Error</Radio>
+      </RadioGroup>
+      <RadioGroup label="Select variant:" value={variant} onChange={setVariant}>
+        <Radio value="filled">Filled</Radio>
+        <Radio value="outlined">Outlined</Radio>
+      </RadioGroup>
+    </div>
+  );
+};
+
+export default SlotsCompoundVariantsExample;

--- a/pages/docs/slots.mdx
+++ b/pages/docs/slots.mdx
@@ -4,6 +4,7 @@ import {
   SlotsVariantsExample,
   CompoundSlotsExample,
 } from "@components";
+import SlotsCompoundVariantsExample from '../../components/examples/slots-compound-variants-example';
 
 # Slots
 
@@ -321,6 +322,188 @@ const App = () => {
 export default App;
 ```
 
+  </Tab>
+</Tabs>
+
+### Slots with compound variants
+
+Like variants, you can also define the styles for each slot when using compound variants. The slots can be passed to the `class` as an object.
+
+<SlotsCompoundVariantsExample />
+
+**React Example:**
+
+<Tabs items={['JS', 'TS']}>
+  <Tab>
+```js filename="Alert.jsx" copy
+import { tv } from 'tailwind-variants';
+
+const alert = tv({
+  slots: {
+    root: 'rounded py-3 px-5',
+    title: 'font-bold mb-1',
+    message: ''
+  },
+  variants: {
+    variant: {
+      outlined: {
+        root: 'border'
+      },
+      filled: {
+        root: ''
+      }
+    },
+    severity: {
+      error: '',
+      success: ''
+    }
+  },
+  compoundVariants: [
+    {
+      variant: 'outlined',
+      severity: 'error',
+      class: {
+        root: 'border-red-500',
+        title: 'text-red-700 dark:text-red-500',
+        message: 'text-red-600'
+      }
+    },
+    {
+      variant: 'outlined',
+      severity: 'success',
+      class: {
+        root: 'border-green-500',
+        title: 'text-green-700 dark:text-green-500',
+        message: 'text-green-500'
+      }
+    },
+    {
+      variant: 'filled',
+      severity: 'error',
+      class: {
+        root: 'bg-red-500',
+        title: 'text-red-100',
+        message: 'text-red-200'
+      }
+    },
+    {
+      variant: 'filled',
+      severity: 'success',
+      class: {
+        root: 'bg-green-500',
+        title: 'text-green-100',
+        message: 'text-green-200'
+      }
+    }
+  ],
+  defaultVariants: {
+    variant: 'filled',
+    severity: 'success'
+  }
+});
+
+const Alert = ({ severity, variant }) => {
+  const { root, message, title } = alert({ severity, variant });
+
+  return (
+    <div className={root()}>
+      <div className={title()}>Oops, something went wrong</div>
+      <div className={message()}>
+        Something went wrong saving your changes. Try again later.
+      </div>
+    </div>
+  );
+};
+
+export default Alert;
+```
+  </Tab>
+  <Tab>
+```js filename="Alert.tsx" copy
+import type { VariantProps } from 'tailwind-variants';
+import { tv } from 'tailwind-variants';
+
+const alert = tv({
+  slots: {
+    root: 'rounded py-3 px-5',
+    title: 'font-bold mb-1',
+    message: ''
+  },
+  variants: {
+    variant: {
+      outlined: {
+        root: 'border'
+      },
+      filled: {
+        root: ''
+      }
+    },
+    severity: {
+      error: '',
+      success: ''
+    }
+  },
+  compoundVariants: [
+    {
+      variant: 'outlined',
+      severity: 'error',
+      class: {
+        root: 'border-red-500',
+        title: 'text-red-700 dark:text-red-500',
+        message: 'text-red-600'
+      }
+    },
+    {
+      variant: 'outlined',
+      severity: 'success',
+      class: {
+        root: 'border-green-500',
+        title: 'text-green-700 dark:text-green-500',
+        message: 'text-green-500'
+      }
+    },
+    {
+      variant: 'filled',
+      severity: 'error',
+      class: {
+        root: 'bg-red-500',
+        title: 'text-red-100',
+        message: 'text-red-200'
+      }
+    },
+    {
+      variant: 'filled',
+      severity: 'success',
+      class: {
+        root: 'bg-green-500',
+        title: 'text-green-100',
+        message: 'text-green-200'
+      }
+    }
+  ],
+  defaultVariants: {
+    variant: 'filled',
+    severity: 'success'
+  }
+});
+
+type Variants = VariantProps<typeof alert>;
+
+const Alert = ({ severity, variant }: Variants) => {
+  const { root, message, title } = alert({ severity, variant });
+
+  return (
+    <div className={root()}>
+      <div className={title()}>Oops, something went wrong</div>
+      <div className={message()}>
+        Something went wrong saving your changes. Try again later.
+      </div>
+    </div>
+  );
+};
+
+export default Alert;
+```
   </Tab>
 </Tabs>
 

--- a/pages/docs/slots.mdx
+++ b/pages/docs/slots.mdx
@@ -3,8 +3,8 @@ import {
   WindowResizer,
   SlotsVariantsExample,
   CompoundSlotsExample,
+  SlotsCompoundVariantsExample,
 } from "@components";
-import SlotsCompoundVariantsExample from '../../components/examples/slots-compound-variants-example';
 
 # Slots
 
@@ -327,14 +327,13 @@ export default App;
 
 ### Slots with compound variants
 
-Like variants, you can also define the styles for each slot when using compound variants. The slots can be passed to the `class` as an object.
+Like variants, you can also define the styles for each slot when using compound
+variants. The slots can be passed to `class` or `className` as an object.
 
 <SlotsCompoundVariantsExample />
 
 **React Example:**
 
-<Tabs items={['JS', 'TS']}>
-  <Tab>
 ```js filename="Alert.jsx" copy
 import { tv } from 'tailwind-variants';
 
@@ -363,18 +362,18 @@ const alert = tv({
       variant: 'outlined',
       severity: 'error',
       class: {
-        root: 'border-red-500',
+        root: 'border-red-700 dark:border-red-500',
         title: 'text-red-700 dark:text-red-500',
-        message: 'text-red-600'
+        message: 'text-red-600 dark:text-red-500'
       }
     },
     {
       variant: 'outlined',
       severity: 'success',
       class: {
-        root: 'border-green-500',
+        root: 'border-green-700 dark:border-green-500',
         title: 'text-green-700 dark:text-green-500',
-        message: 'text-green-500'
+        message: 'text-green-600 dark:text-green-500'
       }
     },
     {
@@ -382,8 +381,8 @@ const alert = tv({
       severity: 'error',
       class: {
         root: 'bg-red-500',
-        title: 'text-red-100',
-        message: 'text-red-200'
+        title: 'text-red-900',
+        message: 'text-red-800'
       }
     },
     {
@@ -391,121 +390,28 @@ const alert = tv({
       severity: 'success',
       class: {
         root: 'bg-green-500',
-        title: 'text-green-100',
-        message: 'text-green-200'
+        title: 'text-green-900',
+        message: 'text-green-800'
       }
     }
-  ],
+  ]
   defaultVariants: {
     variant: 'filled',
     severity: 'success'
   }
 });
 
-const Alert = ({ severity, variant }) => {
-  const { root, message, title } = alert({ severity, variant });
+const { root, message, title } = alert({ severity, variant });
 
-  return (
-    <div className={root()}>
-      <div className={title()}>Oops, something went wrong</div>
-      <div className={message()}>
-        Something went wrong saving your changes. Try again later.
-      </div>
+return (
+  <div className={root()}>
+    <div className={title()}>Oops, something went wrong</div>
+    <div className={message()}>
+      Something went wrong saving your changes. Try again later.
     </div>
-  );
-};
-
-export default Alert;
+  </div>
+);
 ```
-  </Tab>
-  <Tab>
-```js filename="Alert.tsx" copy
-import type { VariantProps } from 'tailwind-variants';
-import { tv } from 'tailwind-variants';
-
-const alert = tv({
-  slots: {
-    root: 'rounded py-3 px-5',
-    title: 'font-bold mb-1',
-    message: ''
-  },
-  variants: {
-    variant: {
-      outlined: {
-        root: 'border'
-      },
-      filled: {
-        root: ''
-      }
-    },
-    severity: {
-      error: '',
-      success: ''
-    }
-  },
-  compoundVariants: [
-    {
-      variant: 'outlined',
-      severity: 'error',
-      class: {
-        root: 'border-red-500',
-        title: 'text-red-700 dark:text-red-500',
-        message: 'text-red-600'
-      }
-    },
-    {
-      variant: 'outlined',
-      severity: 'success',
-      class: {
-        root: 'border-green-500',
-        title: 'text-green-700 dark:text-green-500',
-        message: 'text-green-500'
-      }
-    },
-    {
-      variant: 'filled',
-      severity: 'error',
-      class: {
-        root: 'bg-red-500',
-        title: 'text-red-100',
-        message: 'text-red-200'
-      }
-    },
-    {
-      variant: 'filled',
-      severity: 'success',
-      class: {
-        root: 'bg-green-500',
-        title: 'text-green-100',
-        message: 'text-green-200'
-      }
-    }
-  ],
-  defaultVariants: {
-    variant: 'filled',
-    severity: 'success'
-  }
-});
-
-type Variants = VariantProps<typeof alert>;
-
-const Alert = ({ severity, variant }: Variants) => {
-  const { root, message, title } = alert({ severity, variant });
-
-  return (
-    <div className={root()}>
-      <div className={title()}>Oops, something went wrong</div>
-      <div className={message()}>
-        Something went wrong saving your changes. Try again later.
-      </div>
-    </div>
-  );
-};
-
-export default Alert;
-```
-  </Tab>
-</Tabs>
 
 ### Compound slots
 

--- a/pages/docs/slots.mdx
+++ b/pages/docs/slots.mdx
@@ -1,10 +1,10 @@
-import { Callout, Tabs, Tab } from "nextra-theme-docs";
+import { Callout, Tabs, Tab } from 'nextra-theme-docs';
 import {
   WindowResizer,
   SlotsVariantsExample,
   CompoundSlotsExample,
-  SlotsCompoundVariantsExample,
-} from "@components";
+  SlotsCompoundVariantsExample
+} from '@components';
 
 # Slots
 
@@ -25,19 +25,19 @@ You can add slots by using the `slots` key. There's no limit to how many slots y
 />
 
 ```js copy /base/1 /avatar/1 /wrapper/1 /description/1 /infoWrapper/1 /name/1 /role/1 /base()/ /avatar()/ /wrapper()/ /description()/ /infoWrapper()/ /name()/ /role()/
-import { tv } from "tailwind-variants";
+import { tv } from 'tailwind-variants';
 
 const card = tv({
   slots: {
-    base: "md:flex bg-slate-100 rounded-xl p-8 md:p-0 dark:bg-gray-900",
+    base: 'md:flex bg-slate-100 rounded-xl p-8 md:p-0 dark:bg-gray-900',
     avatar:
-      "w-24 h-24 md:w-48 md:h-auto md:rounded-none rounded-full mx-auto drop-shadow-lg",
-    wrapper: "flex-1 pt-6 md:p-8 text-center md:text-left space-y-4",
-    description: "text-md font-medium",
-    infoWrapper: "font-medium",
-    name: "text-sm text-sky-500 dark:text-sky-400",
-    role: "text-sm text-slate-700 dark:text-slate-500",
-  },
+      'w-24 h-24 md:w-48 md:h-auto md:rounded-none rounded-full mx-auto drop-shadow-lg',
+    wrapper: 'flex-1 pt-6 md:p-8 text-center md:text-left space-y-4',
+    description: 'text-md font-medium',
+    infoWrapper: 'font-medium',
+    name: 'text-sm text-sky-500 dark:text-sky-400',
+    role: 'text-sm text-slate-700 dark:text-slate-500'
+  }
 });
 
 const { base, avatar, wrapper, description, infoWrapper, name, role } = card();
@@ -89,57 +89,55 @@ You can also change the entire component and its slots by using the `variants`. 
   <Tab>
 
 ```js filename="App.jsx" copy /buyButton/ /sizeButton/ /addToBagButton/
-import { useState } from "react";
-import { tv } from "tailwind-variants";
+import { useState } from 'react';
+import { tv } from 'tailwind-variants';
 // Import your components
-import { RadioGroup, Radio } from "@components";
+import { RadioGroup, Radio } from '@components';
 
 const item = tv({
   slots: {
-    base:
-      "flex flex-col mb-4 sm:flex-row p-6 bg-white dark:bg-stone-900 drop-shadow-xl rounded-xl",
+    base: 'flex flex-col mb-4 sm:flex-row p-6 bg-white dark:bg-stone-900 drop-shadow-xl rounded-xl',
     imageWrapper:
-      "flex-none w-full sm:w-48 h-48 mb-6 sm:mb-0 sm:h-auto relative z-10 before:absolute before:top-0 before:left-0 before:w-full before:h-full before:rounded-xl before:bg-[#18000E] before:bg-gradient-to-r before:from-[#010187]",
-    img:
-      "sm:scale-125 absolute z-10 top-2 sm:left-2 inset-0 w-full h-full object-cover rounded-lg",
+      'flex-none w-full sm:w-48 h-48 mb-6 sm:mb-0 sm:h-auto relative z-10 before:absolute before:top-0 before:left-0 before:w-full before:h-full before:rounded-xl before:bg-[#18000E] before:bg-gradient-to-r before:from-[#010187]',
+    img: 'sm:scale-125 absolute z-10 top-2 sm:left-2 inset-0 w-full h-full object-cover rounded-lg',
     title:
-      "relative w-full flex-none mb-2 text-2xl font-semibold text-stone-900 dark:text-white",
-    price: "relative font-semibold text-xl dark:text-white",
-    previousPrice: "relative line-through font-bold text-neutral-500 ml-3",
-    percentOff: "relative font-bold text-green-500 ml-3",
+      'relative w-full flex-none mb-2 text-2xl font-semibold text-stone-900 dark:text-white',
+    price: 'relative font-semibold text-xl dark:text-white',
+    previousPrice: 'relative line-through font-bold text-neutral-500 ml-3',
+    percentOff: 'relative font-bold text-green-500 ml-3',
     sizeButton:
-      "cursor-pointer select-none relative font-semibold rounded-full w-10 h-10 flex items-center justify-center active:opacity-80 dark:text-white peer-checked:text-white",
+      'cursor-pointer select-none relative font-semibold rounded-full w-10 h-10 flex items-center justify-center active:opacity-80 dark:text-white peer-checked:text-white',
     buyButton:
-      "text-xs sm:text-sm px-4 h-10 rounded-lg shadow-lg uppercase font-semibold tracking-wider text-white active:opacity-80",
+      'text-xs sm:text-sm px-4 h-10 rounded-lg shadow-lg uppercase font-semibold tracking-wider text-white active:opacity-80',
     addToBagButton:
-      "text-xs sm:text-sm px-4 h-10 rounded-lg uppercase font-semibold tracking-wider border-2 active:opacity-80",
+      'text-xs sm:text-sm px-4 h-10 rounded-lg uppercase font-semibold tracking-wider border-2 active:opacity-80'
   },
   variants: {
     color: {
       primary: {
-        buyButton: "bg-blue-500 shadow-blue-500/50",
-        sizeButton: "peer-checked:bg-blue",
-        addToBagButton: "text-blue-500 border-blue-500",
+        buyButton: 'bg-blue-500 shadow-blue-500/50',
+        sizeButton: 'peer-checked:bg-blue',
+        addToBagButton: 'text-blue-500 border-blue-500'
       },
       secondary: {
-        buyButton: "bg-purple-500 shadow-purple-500/50",
-        sizeButton: "peer-checked:bg-purple",
-        addToBagButton: "text-purple-500 border-purple-500",
+        buyButton: 'bg-purple-500 shadow-purple-500/50',
+        sizeButton: 'peer-checked:bg-purple',
+        addToBagButton: 'text-purple-500 border-purple-500'
       },
       success: {
-        buyButton: "bg-green-500 shadow-green-500/50",
-        sizeButton: "peer-checked:bg-green",
-        addToBagButton: "text-green-500 border-green-500",
-      },
-    },
-  },
+        buyButton: 'bg-green-500 shadow-green-500/50',
+        sizeButton: 'peer-checked:bg-green',
+        addToBagButton: 'text-green-500 border-green-500'
+      }
+    }
+  }
 });
 
-const itemSizes = ["xs", "s", "m", "l", "xl"];
+const itemSizes = ['xs', 's', 'm', 'l', 'xl'];
 
 const App = () => {
-  const [size, setSize] = useState("xs");
-  const [color, setColor] = useState("primary");
+  const [size, setSize] = useState('xs');
+  const [color, setColor] = useState('primary');
 
   const {
     base,
@@ -151,7 +149,7 @@ const App = () => {
     percentOff,
     sizeButton,
     buyButton,
-    addToBagButton,
+    addToBagButton
   } = item({ color });
 
   return (
@@ -167,13 +165,13 @@ const App = () => {
             <div className={previousPrice()}>$350</div>
             <div className={percentOff()}>20% off</div>
           </div>
-          <div className="flex items-baseline my-4">
-            <div className="space-x-3 flex text-sm font-medium">
+          <div className="my-4 flex items-baseline">
+            <div className="flex space-x-3 text-sm font-medium">
               {itemSizes.map((itemSize) => (
                 <label key={itemSize}>
                   <input
                     checked={size === itemSize}
-                    className="sr-only peer"
+                    className="peer sr-only"
                     name="size"
                     type="radio"
                     value={itemSize}
@@ -330,6 +328,8 @@ export default App;
 Like variants, you can also define the styles for each slot when using compound
 variants. The slots can be passed to `class` or `className` as an object.
 
+<br />
+
 <SlotsCompoundVariantsExample />
 
 **React Example:**
@@ -339,7 +339,7 @@ import { tv } from 'tailwind-variants';
 
 const alert = tv({
   slots: {
-    root: 'rounded py-3 px-5',
+    root: 'rounded py-3 px-5 mb-4',
     title: 'font-bold mb-1',
     message: ''
   },
@@ -380,21 +380,21 @@ const alert = tv({
       variant: 'filled',
       severity: 'error',
       class: {
-        root: 'bg-red-500',
-        title: 'text-red-900',
-        message: 'text-red-800'
+        root: 'bg-red-100 dark:bg-red-800',
+        title: 'text-red-900 dark:text-red-50',
+        message: 'text-red-700 dark:text-red-200'
       }
     },
     {
       variant: 'filled',
       severity: 'success',
       class: {
-        root: 'bg-green-500',
-        title: 'text-green-900',
-        message: 'text-green-800'
+        root: 'bg-green-100 dark:bg-green-800',
+        title: 'text-green-900 dark:text-green-50',
+        message: 'text-green-700 dark:text-green-200'
       }
     }
-  ]
+  ],
   defaultVariants: {
     variant: 'filled',
     severity: 'success'
@@ -422,60 +422,60 @@ Compound slots allow apply classes to multiple slots at once. This avoids having
 <CompoundSlotsExample />
 
 ```js copy {23} /compoundSlots/ /"base"/ /"item"/ /"prev"/ /"next"/ /base()/ /item()/ /prev()/ /next()/
-import { tv } from "tailwind-variants";
+import { tv } from 'tailwind-variants';
 
 const pagination = tv({
   slots: {
-    base: "flex flex-wrap relative gap-1 max-w-fit",
+    base: 'flex flex-wrap relative gap-1 max-w-fit',
     item: 'data-[active="true"]:bg-blue-500 data-[active="true"]:text-white',
-    prev: "",
-    next: "",
+    prev: '',
+    next: ''
   },
   variants: {
     size: {
       xs: {},
       sm: {},
-      md: {},
-    },
+      md: {}
+    }
   },
   defaultVariants: {
-    size: "md",
+    size: 'md'
   },
   compoundSlots: [
     // if you dont specify any variant, it will always be applied
     {
-      slots: ["item", "prev", "next"],
+      slots: ['item', 'prev', 'next'],
       class: [
-        "flex",
-        "flex-wrap",
-        "truncate",
-        "box-border",
-        "outline-none",
-        "items-center",
-        "justify-center",
-        "bg-neutral-100",
-        "hover:bg-neutral-200",
-        "active:bg-neutral-300",
-        "text-neutral-500",
-      ], // --> these classes will be applied to all slots
+        'flex',
+        'flex-wrap',
+        'truncate',
+        'box-border',
+        'outline-none',
+        'items-center',
+        'justify-center',
+        'bg-neutral-100',
+        'hover:bg-neutral-200',
+        'active:bg-neutral-300',
+        'text-neutral-500'
+      ] // --> these classes will be applied to all slots
     },
     // if you specify a variant, it will only be applied if the variant is active
     {
-      slots: ["item", "prev", "next"],
-      size: "xs",
-      class: "w-7 h-7 text-xs", // --> these classes will be applied to all slots if size is xs
+      slots: ['item', 'prev', 'next'],
+      size: 'xs',
+      class: 'w-7 h-7 text-xs' // --> these classes will be applied to all slots if size is xs
     },
     {
-      slots: ["item", "prev", "next"],
-      size: "sm",
-      class: "w-8 h-8 text-sm", // --> these classes will be applied to all slots if size is sm
+      slots: ['item', 'prev', 'next'],
+      size: 'sm',
+      class: 'w-8 h-8 text-sm' // --> these classes will be applied to all slots if size is sm
     },
     {
-      slots: ["item", "prev", "next"],
-      size: "md",
-      class: "w-9 h-9 text-base", // --> these classes will be applied to all slots if size is md
-    },
-  ],
+      slots: ['item', 'prev', 'next'],
+      size: 'md',
+      class: 'w-9 h-9 text-base' // --> these classes will be applied to all slots if size is md
+    }
+  ]
 });
 
 // React implementation
@@ -491,7 +491,7 @@ const App = () => {
         data-disabled="true"
         role="button"
       >
-        {"<"}
+        {'<'}
       </li>
       <li aria-label="page 1" className={item()} role="button">
         1
@@ -520,7 +520,7 @@ const App = () => {
         10
       </li>
       <li aria-label="Go to next page" className={next()} role="button">
-        {">"}
+        {'>'}
       </li>
     </ul>
   );
@@ -608,51 +608,51 @@ const pagination = tv({
 />
 
 ```js copy {34, 39-41} /base/ /name/ /role/ /base()/ /name()/ /role()/
-import { tv } from "tailwind-variants";
+import { tv } from 'tailwind-variants';
 
 const card = tv(
   {
     slots: {
-      base: "md:flex rounded-xl p-8 md:p-0 ",
+      base: 'md:flex rounded-xl p-8 md:p-0 ',
       avatar:
-        "w-24 h-24 md:w-48 md:h-auto md:rounded-none rounded-full mx-auto drop-shadow-lg",
-      wrapper: "flex-1 pt-6 md:p-8 text-center md:text-left space-y-4",
-      description: "text-md font-medium",
-      infoWrapper: "font-medium",
-      name: "text-sm",
-      role: "text-sm",
+        'w-24 h-24 md:w-48 md:h-auto md:rounded-none rounded-full mx-auto drop-shadow-lg',
+      wrapper: 'flex-1 pt-6 md:p-8 text-center md:text-left space-y-4',
+      description: 'text-md font-medium',
+      infoWrapper: 'font-medium',
+      name: 'text-sm',
+      role: 'text-sm'
     },
     variants: {
       color: {
         primary: {
-          base: "bg-blue-100 dark:bg-blue-900",
-          name: "text-blue-500 dark:text-blue-400",
-          role: "text-blue-700 dark:text-blue-500",
+          base: 'bg-blue-100 dark:bg-blue-900',
+          name: 'text-blue-500 dark:text-blue-400',
+          role: 'text-blue-700 dark:text-blue-500'
         },
         secondary: {
-          base: "bg-purple-100 dark:bg-purple-900",
-          name: "text-purple-500 dark:text-purple-400",
-          role: "text-purple-700 dark:text-purple-500",
+          base: 'bg-purple-100 dark:bg-purple-900',
+          name: 'text-purple-500 dark:text-purple-400',
+          role: 'text-purple-700 dark:text-purple-500'
         },
         warning: {
-          base: "bg-yellow-100 dark:bg-yellow-900",
-          name: "text-yellow-500 dark:text-yellow-400",
-          role: "text-yellow-700 dark:text-yellow-500",
-        },
-      },
-    },
+          base: 'bg-yellow-100 dark:bg-yellow-900',
+          name: 'text-yellow-500 dark:text-yellow-400',
+          role: 'text-yellow-700 dark:text-yellow-500'
+        }
+      }
+    }
   },
   {
-    responsiveVariants: ["sm", "md"], // `true` to apply to all screen sizes
+    responsiveVariants: ['sm', 'md'] // `true` to apply to all screen sizes
   }
 );
 
 const { base, avatar, wrapper, description, infoWrapper, name, role } = card({
   color: {
-    initial: "primary",
-    sm: "secondary",
-    md: "warning",
-  },
+    initial: 'primary',
+    sm: 'secondary',
+    md: 'warning'
+  }
 });
 
 return (
@@ -683,7 +683,7 @@ return (
 
 <details>
   <summary>Troubleshooting: The responsive variants are not working</summary>
-  <ul className="pl-3 py-2">
+  <ul className="py-2 pl-3">
     <li>
       - Make sure you have followed this
       [step](/docs/getting-started#responsive-variants-optional)
@@ -703,31 +703,31 @@ level variant overrides to make it simple to override the selected variant(s)
 per slot as necessary.
 
 ```js copy {30} /isSelected/
-import { tv } from "tailwind-variants";
+import { tv } from 'tailwind-variants';
 
 const card = tv({
   slots: {
-    base: "flex gap-2",
-    tab: "rounded",
+    base: 'flex gap-2',
+    tab: 'rounded'
   },
   variants: {
     color: {
       primary: {
-        tab: "text-blue-500 dark:text-blue-400",
+        tab: 'text-blue-500 dark:text-blue-400'
       },
       secondary: {
-        tab: "text-purple-500 dark:text-purple-400",
-      },
+        tab: 'text-purple-500 dark:text-purple-400'
+      }
     },
     isSelected: {
       true: {
-        tab: "font-bold",
-      },
-    },
-  },
+        tab: 'font-bold'
+      }
+    }
+  }
 });
 
-const { base, tab } = card({ color: "primary" });
+const { base, tab } = card({ color: 'primary' });
 
 return (
   <Tabs className={base()}>


### PR DESCRIPTION
Added a section to the slots page to show how to use slots with compound variants.
<img width="1680" alt="image" src="https://github.com/nextui-org/tailwind-variants-docs/assets/7714133/e3ff075c-a8df-4eaf-a6f1-79836dcd3a84">

Feel free to take over and change the example for a different one.