### PR TITLE
Fix nested p tags

### DIFF
--- a/components/collapse/collapse.tsx
+++ b/components/collapse/collapse.tsx
@@ -9,7 +9,7 @@ const Collaspe: FC<CollapseProps> = ({ title, children }) => {
   return (
     <details>
       <summary>{title}</summary>
-      <p className="py-2 pl-3">{children}</p>
+      <div className="py-2 pl-3">{children}</div>
     </details>
   );
 };

--- a/pages/docs/getting-started.mdx
+++ b/pages/docs/getting-started.mdx
@@ -123,13 +123,13 @@ module.exports = withTV({
 
 <details>
   <summary>Why do I need to add the transformer?</summary>
-  <p className="pl-3 py-2">
+  <div className="pl-3 py-2">
     If you are wondering why you need to add the transformer, it's because **TailwindCSS** uses
     something called [JIT](https://tailwindcss.com/blog/tailwindcss-v3#just-in-time-all-the-time)
     which compiles your CSS on demand based on the classes you use in your HTML / JSX files / etc.
     As the responsive variants need to be dynamic the JIT compiler doesn't know what classes to compile,
     so we need to add the transformer to tell the compiler what classes to compile.
-  </p>
+  </div>
 </details>
 
 

--- a/pages/docs/slots.mdx
+++ b/pages/docs/slots.mdx
@@ -531,14 +531,14 @@ export default App;
 
 <details>
   <summary>Can I do the same with variants?</summary>
-  <p className="pl-3 py-2">
+  <div className="pl-3 py-2">
     Yes, you can do the same with variants. However, compound slots allows you
     to write the classes only once and apply them to multiple slots. This is
     useful if you have a lot of slots and you want to apply the same classes to
     all of them.
-  </p>
+  </div>
 
-  <p className="pl-3 py-2">
+  <div className="pl-3 py-2">
     For example, let's write the same component using variants:
 
 ```js copy
@@ -590,7 +590,7 @@ const pagination = tv({
 });
 ```
 
-  </p>
+  </div>
 </details>
 
 ### Slots with responsive variants


### PR DESCRIPTION
Nesting p tags is not valid HTML which causes local dev server warnings. This fixes the collapse element which had this issue.