### PR TITLE
fix(docs): installation commands

### DIFF
--- a/pages/docs/getting-started.mdx
+++ b/pages/docs/getting-started.mdx
@@ -14,22 +14,27 @@ TailwindCSS yet, you can follow the [TailwindCSS installation guide](https://tai
 
 To use **Tailwind Variants** in your project, you can install it as a dependency:
 
-{/* prettier-ignore */}
 <Tabs items={['npm', 'yarn', 'pnpm']}>
   <Tab>
-    ```bash copy 
+
+    ```bash copy
     npm install tailwind-variants
     ```
+
   </Tab>
   <Tab>
-    ```bash copy 
+
+    ```bash copy
     yarn add tailwind-variants
     ```
+
   </Tab>
   <Tab>
-    ```bash copy 
+
+    ```bash copy
     pnpm add tailwind-variants
     ```
+
   </Tab>
 </Tabs>
 

--- a/pages/docs/getting-started.mdx
+++ b/pages/docs/getting-started.mdx
@@ -14,10 +14,23 @@ TailwindCSS yet, you can follow the [TailwindCSS installation guide](https://tai
 
 To use **Tailwind Variants** in your project, you can install it as a dependency:
 
+{/* prettier-ignore */}
 <Tabs items={['npm', 'yarn', 'pnpm']}>
-  <Tab>```bash copy npm install tailwind-variants ```</Tab>
-  <Tab>```bash copy yarn add tailwind-variants ```</Tab>
-  <Tab>```bash copy pnpm add tailwind-variants ```</Tab>
+  <Tab>
+    ```bash copy 
+    npm install tailwind-variants
+    ```
+  </Tab>
+  <Tab>
+    ```bash copy 
+    yarn add tailwind-variants
+    ```
+  </Tab>
+  <Tab>
+    ```bash copy 
+    pnpm add tailwind-variants
+    ```
+  </Tab>
 </Tabs>
 
 ## Usage


### PR DESCRIPTION
## Summary

`fmt` (`prettier --write .`) would make the command block under Installation become one line, which makes `nextra-theme-docs` fails to parse. 

This PR is to 
- make the command block correct so that `nextra-theme-docs` can parse successfully 
- add `{/* prettier-ignore */}` there so that it won't prettier the command block to one line whenever we run `fmt`.

## Verification

p.s. applied to all three tabs

Before:

![image](https://github.com/nextui-org/tailwind-variants-docs/assets/35857179/5043a4bf-a9ac-4129-92ed-0cfdd475f0c6)

After:

![image](https://github.com/nextui-org/tailwind-variants-docs/assets/35857179/90e38af5-fdea-416c-a112-f5c4778984bb)
