### PR TITLE
fix: incorrect flag in fmt:check

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "next lint",
     "lint:fix": "next lint --fix",
     "fmt": "prettier --write .",
-    "fmt:check": "prettier --write ."
+    "fmt:check": "prettier --check ."
   },
   "dependencies": {
     "@react-aria/interactions": "3.17.0",


### PR DESCRIPTION
## Summary

Currently `fmt:check` is same as `fmt`, this PR is to update the correct flag based on the name.