### PR TITLE
Update IntelliSense instructions to the current up to date method

### DIFF
--- a/pages/docs/getting-started.mdx
+++ b/pages/docs/getting-started.mdx
@@ -210,12 +210,7 @@ To enable autocompletion for **Tailwind Variants** you can follow the instructio
     If you are using **IntelliJ** and the [**Tailwind CSS Plugin**](https://plugins.jetbrains.com/plugin/15321-tailwind-css), go to **settings** -> **Languages & Frameworks** -> **Style Sheets** -> **Tailwind CSS** and add the following to the configuration.
 
      ```json copy
-     "experimental": {
-       "configFile": null,
-       "classRegex": [
-          ["(`.*?`)", "(\".*?\")", "('.*?')"]
-       ]
-     }
+     "tailwindCSS.classFunctions": ["tv"]
     ```
 
   </Tab>
@@ -227,11 +222,12 @@ If you are using [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/p
 to sort your class names, you can add `tv` to the list of functions that
 should be sorted.
 
-```js
-module.exports = {
-  plugins: [require('prettier-plugin-tailwindcss')],
-  tailwindFunctions: ['tv']
-};
+```json
+// .prettierrc
+"plugins": [
+  "prettier-plugin-tailwindcss"
+],
+"tailwindFunctions": ["tv"]
 ```
 
 ## Contributing

--- a/pages/docs/getting-started.mdx
+++ b/pages/docs/getting-started.mdx
@@ -171,7 +171,7 @@ To enable autocompletion for **Tailwind Variants** you can follow the instructio
 
     ```json copy
     {
-      "tailwindCSS.classFunctions": ["tv"]
+      "classFunctions": ["tv"]
     }
     ```
 


### PR DESCRIPTION
The current guide is out of date, and in fact doesn't even work (the correct `tailwindCSS.experimental.classRegex` for WebStorm should be ```["tv\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]```).